### PR TITLE
Add PowerDNS as ReST user example

### DIFF
--- a/rfcs/0064-documentation-format.md
+++ b/rfcs/0064-documentation-format.md
@@ -134,6 +134,8 @@ Examples of users:
 - CMake
 - LLVM
 - Majority of Python packages
+- PowerDNS: ReST with [Sphinx](https://www.sphinx-doc.org/) for
+  manuals, guides and manpages
 
 ### Asciidoc
 


### PR DESCRIPTION
It's an interesting example because they are generating a lot of
different kind of documentation, including manpages.